### PR TITLE
optional suppress_progress_messages, and better solved cube handling

### DIFF
--- a/pycuber/solver/cfop/__init__.py
+++ b/pycuber/solver/cfop/__init__.py
@@ -17,7 +17,7 @@ class CFOPSolver(object):
     def feed(self, cube):
         self.cube = cube
 
-    def solve(self, suppress_progress_messages):
+    def solve(self, suppress_progress_messages=False):
         if suppress_progress_messages:
             save_stdout = sys.stdout
             sys.stdout = generalized_io.StringIO()
@@ -32,15 +32,12 @@ class CFOPSolver(object):
         sys.stdout.write("\rCross: {0}\n".format(cross))
 
         solver = F2LSolver(self.cube)
-        try:
-            f2lall = solver.solve()
-            for i in range(4):
-                sys.stdout.write("\rSolving F2L#{0} ......".format(i))
-                f2l = next(f2lall)
-                result += f2l[1]
-                sys.stdout.write("\rF2L{0}: {1}\n".format(*f2l))
-        except StopIteration:
-            sys.stdout.write('\nCube might be already solved? \n')
+        f2lall = solver.solve()
+        for i, f2l in enumerate(f2lall):
+            sys.stdout.write("\rSolving F2L#{0} ......".format(i))
+            result += f2l[1]
+            sys.stdout.write("\rF2L{0}: {1}\n".format(*f2l))
+        
         solver = OLLSolver(self.cube)
         sys.stdout.write("\rSolving OLL ......")
         oll = solver.solve()

--- a/pycuber/tests/test_basic_solve.py
+++ b/pycuber/tests/test_basic_solve.py
@@ -1,0 +1,20 @@
+import pycuber as pc
+from pycuber.solver import CFOPSolver
+
+"""These two tests only make sure no uncaught errors get raised.
+    They do not test the validity of the solve.
+"""
+
+def test_for_basic_ability_to_solve():
+    c = pc.Cube()
+    alg = pc.Formula()
+    random_alg = alg.random()
+    c(random_alg)
+    solver = CFOPSolver(c)
+    solver.solve()
+
+
+def test_solving_a_solved_cube():
+    c = pc.Cube()
+    solver = CFOPSolver(c)
+    solver.solve()


### PR DESCRIPTION
This addresses the issues you raised in your comment to #11 

FIXED: supress_progress_messages is now optional (I didn’t realize that
got removed…)
ADJUSTED: f2l solving now iterates through an enumerated F2LSolver,
which more cleanly handles the stop iteration error.
ADDED: tests for checking that the solver can complete both an actual solve and an non-solve solve without raising an error. 
